### PR TITLE
Add Nav component with title of current Kata

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react": "15.0.2",
     "react-native": "^0.26.3",
     "react-native-fs": "^1.4.0",
+    "react-native-navbar": "^1.5.0",
     "react-native-vector-icons": "^2.0.3"
   }
 }

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -7,6 +7,7 @@ import ReactNative, {
 } from 'react-native'
 
 import Done from './done'
+import Nav from './nav'
 
 class Runner extends Component {
   constructor(props){
@@ -53,7 +54,12 @@ class Runner extends Component {
     if(!CurrentComponent){
       return <View><Text>No Component!</Text></View>
     }
-    return <CurrentComponent onCompared={(similar)=>similar && this._advance()} />
+    return (
+      <View style={{flex:1}}>
+        <Nav text={CurrentComponent.displayName} />
+        <CurrentComponent onCompared={(similar)=>similar && this._advance()} />
+      </View>
+    )
   }
 }
 import kata from './kata'

--- a/src/runner/nav.js
+++ b/src/runner/nav.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import NavigationBar from 'react-native-navbar'
+
+export default function Nav(props) {
+  return (
+    <NavigationBar title={{tintColor:'#cccccc', title:props.text}} />
+  )
+}


### PR DESCRIPTION
This is one solution to addressing the problem where we want to be able to know the name of the current Kata in order to know which file to edit.

Some of the Katas have `<Text />` labels with their names which works very well. However, for some Katas, the `<Text />` would interfere with the styling of the Kata itself.

This approach instead adds a Nav bar at the top of the Kata runner in the simulator. This allows us to both see the name of the current Kata as well as render the Kata without interference.

 * Install `NavigationBar` from `react-native-navbar`
 * Create own `Nav` component wrapping `NavigationBar`
 * Wrap `Runner` in `<View />` with `Nav` and Kata as children