### PR TITLE
remove answer from flex/Direction kata

### DIFF
--- a/src/katas/flex/Direction.test.js
+++ b/src/katas/flex/Direction.test.js
@@ -26,7 +26,7 @@ const Direction= (props)=>{
       <Box/>
       <Box/>
       <Box/>
-      <View style={{flexDirection:'row'}}>
+      <View style={{}}>
         <Box/>
         <Box/>
         <Box/>


### PR DESCRIPTION
This should resolve issue #10.
Reading the comments in the kata, I think this is what was intended all along. Without this the solution only involves changes with the flex tag, not flexDirection.